### PR TITLE
feat: add initial infra

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,6 @@
+.terraform.*
+.terraform/*
+# .terraform.lock.hcl
+errored.tfstate
+terraform.tfstate
+terraform.tfstate.backup

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -4,3 +4,4 @@
 errored.tfstate
 terraform.tfstate
 terraform.tfstate.backup
+.env

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -9,110 +9,82 @@ terraform {
 
 
 # Create a VPC
-resource "aws_vpc" "vpc-prod-sa-east-1-autonome" {
+resource "aws_vpc" "vpc-prod-autonome" {
   cidr_block = "10.0.0.0/16"
+  enable_dns_support   = true 
+  enable_dns_hostnames = true
 }
 
-## subnet publica sa-east-1a
-resource "aws_subnet" "prod-public_subnet-sa-east-1" {
-  vpc_id            = aws_vpc.vpc-prod-sa-east-1-autonome.id
+resource "aws_subnet" "subnet1" {
+  vpc_id            = aws_vpc.vpc-prod-autonome.id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "sa-east-1a"
-  map_public_ip_on_launch = true 
-
-  tags = {
-    Name = "subnet-prod-sa-east-1-public"
-  }
 }
 
-# internet gateway
-resource "aws_internet_gateway" "igw" {
-  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
-
-  tags = {
-    Name = "igw-prod-sa-east-1"
-  }
-}
-
-# route table
-resource "aws_route_table" "public_rt" {
-  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.igw.id
-  }
-
-  tags = {
-    Name = "rt-prod-sa-east-1-public"
-  }
-}
-
-# associação subnet e route table publica 
-resource "aws_route_table_association" "public_assoc" {
-  subnet_id      = aws_subnet.prod-public_subnet-sa-east-1.id
-  route_table_id = aws_route_table.public_rt.id
-}
-
-
-# Criando segunda subnet
-resource "aws_subnet" "prod-private_subnet-sa-east-1" {
-  vpc_id            = aws_vpc.vpc-prod-sa-east-1-autonome.id
+resource "aws_subnet" "subnet2" {
+  vpc_id            = aws_vpc.vpc-prod-autonome.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "sa-east-1a"
-
-  tags = {
-    Name = "subnet-prod-sa-east-1a-private"
-  }
+  availability_zone = "sa-east-1b"
+}
+resource "aws_internet_gateway" "internet-gw" {
+  vpc_id = aws_vpc.vpc-prod-autonome.id
 }
 
-#criando route table privada
-resource "aws_route_table" "private_rt" {
-  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
-
-  tags = {
-    Name = "rt-prod-sa-east-1-private"
-  }
-}
-
-# associando subnet privada com route table privada
-resource "aws_route_table_association" "private_assoc" {
-  subnet_id      = aws_subnet.prod-private_subnet-sa-east-1.id
-  route_table_id = aws_route_table.private_rt.id
-}
-
-# criando security group
 resource "aws_security_group" "rds_sg" {
-  name_prefix = "rds-"
+  vpc_id = aws_vpc.vpc-prod-autonome.id
 
-  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
-
-  # Add any additional ingress/egress rules as needed
   ingress {
     from_port   = 5432
     to_port     = 5432
     protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # Restrinja isso para IPs específicos
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
-## criando um rds com postgres
-resource "aws_db_instance" "rds" {
-  allocated_storage    = 20
-  engine               = "postgres"
-  storage_type = "gp2"
-  engine_version       = "11.5"
-  instance_class       = "db.t2.micro"
-  username             = "myuser"
-  password             = process.env.DB_PASSWORD
-  skip_final_snapshot  = true
+
+resource "aws_db_instance" "postgres" {
+  identifier           = "meu-rds-postgres"
+  engine              = "postgres"
+  engine_version      = "16.4"
+  instance_class      = "db.t3.micro"
+  allocated_storage   = 20
+  storage_type        = "gp2"
+  db_name             = "meubanco"
+  username           = "autonome"
+  password           = []
+  publicly_accessible = true
+  skip_final_snapshot = true
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
 }
 
-# criando um grupo de subnet para o rds
-resource "aws_db_subnet_group" "db_subnet_group" {
-  name = "db-subnet-group"
-  subnet_ids = [aws_subnet.prod-private_subnet-sa-east-1.id]
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name       = "rds-subnet-group"
+  subnet_ids = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
+}
 
-  tags = {
-    Name = " DB Subnet Group"
+resource "aws_route_table" "rt" {
+  vpc_id = aws_vpc.vpc-prod-autonome.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet-gw.id
   }
 }
+
+resource "aws_route_table_association" "subnet1_assoc" {
+  subnet_id      = aws_subnet.subnet1.id
+  route_table_id = aws_route_table.rt.id
+}
+
+resource "aws_route_table_association" "subnet2_assoc" {
+  subnet_id      = aws_subnet.subnet2.id
+  route_table_id = aws_route_table.rt.id
+}
+

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -81,3 +81,38 @@ resource "aws_route_table_association" "private_assoc" {
   route_table_id = aws_route_table.private_rt.id
 }
 
+# criando security group
+resource "aws_security_group" "rds_sg" {
+  name_prefix = "rds-"
+
+  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
+
+  # Add any additional ingress/egress rules as needed
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+## criando um rds com postgres
+resource "aws_db_instance" "rds" {
+  allocated_storage    = 20
+  engine               = "postgres"
+  storage_type = "gp2"
+  engine_version       = "11.5"
+  instance_class       = "db.t2.micro"
+  username             = "myuser"
+  password             = process.env.DB_PASSWORD
+  skip_final_snapshot  = true
+}
+
+# criando um grupo de subnet para o rds
+resource "aws_db_subnet_group" "db_subnet_group" {
+  name = "db-subnet-group"
+  subnet_ids = [aws_subnet.prod-private_subnet-sa-east-1.id]
+
+  tags = {
+    Name = " DB Subnet Group"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+
+# Create a VPC
+resource "aws_vpc" "vpc-prod-sa-east-1-autonome" {
+  cidr_block = "10.0.0.0/16"
+}
+
+## subnet publica sa-east-1a
+resource "aws_subnet" "prod-public_subnet-sa-east-1" {
+  vpc_id            = aws_vpc.vpc-prod-sa-east-1-autonome.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "sa-east-1a"
+  map_public_ip_on_launch = true 
+
+  tags = {
+    Name = "subnet-prod-sa-east-1-public"
+  }
+}
+
+# internet gateway
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
+
+  tags = {
+    Name = "igw-prod-sa-east-1"
+  }
+}
+
+# route table
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "rt-prod-sa-east-1-public"
+  }
+}
+
+# associação subnet e route table publica 
+resource "aws_route_table_association" "public_assoc" {
+  subnet_id      = aws_subnet.prod-public_subnet-sa-east-1.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+
+# Criando segunda subnet
+resource "aws_subnet" "prod-private_subnet-sa-east-1" {
+  vpc_id            = aws_vpc.vpc-prod-sa-east-1-autonome.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "sa-east-1a"
+
+  tags = {
+    Name = "subnet-prod-sa-east-1a-private"
+  }
+}
+
+#criando route table privada
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.vpc-prod-sa-east-1-autonome.id
+
+  tags = {
+    Name = "rt-prod-sa-east-1-private"
+  }
+}
+
+# associando subnet privada com route table privada
+resource "aws_route_table_association" "private_assoc" {
+  subnet_id      = aws_subnet.prod-private_subnet-sa-east-1.id
+  route_table_id = aws_route_table.private_rt.id
+}
+

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "sa-east-1"
+}


### PR DESCRIPTION
This pull request introduces infrastructure as code for setting up AWS resources using Terraform. The changes include adding new AWS resources such as VPC, subnets, security groups, and an RDS instance, as well as updating the `.gitignore` file to exclude Terraform-related files.

Infrastructure setup:

* [`infra/main.tf`](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668R1-R90): Added configuration for setting up a VPC, subnets, an internet gateway, security groups, an RDS instance, and route tables. This includes defining the necessary resources and their properties.
* [`infra/provider.tf`](diffhunk://#diff-41f8c2a70e267281aa1bca58cc75bda58efea111a2e3b547d971441c5c08be10R1-R3): Configured the AWS provider to use the `sa-east-1` region.

Gitignore updates:

* [`infra/.gitignore`](diffhunk://#diff-9a136429a515fc729e6af87248b9287225a07477f6523e900abafb6a76943c6eR1-R7): Added entries to ignore Terraform-related files and environment files.configuring initial infrastructure for RDS database